### PR TITLE
Auto Replace Hosts in .env when using docker

### DIFF
--- a/bin/serve
+++ b/bin/serve
@@ -21,7 +21,7 @@ fi
 # Create environment file if it doesn't exist yet
 if [ ! -f .env ]
 then
-    cp .env.example .env
+    sed 's/APP_URL=.*/APP_URL=http:\/\/localhost/g;s/DB_HOST=.*/DB_HOST=mysql/g;s/REDIS_HOST=.*/REDIS_HOST=redis/g;s/MAIL_HOST=.*/MAIL_HOST=mailpit/g' < .env.example > .env
     FRESH=true
 fi
 


### PR DESCRIPTION
I added an automatic replacement of the XXX_HOST and APP_URL in the .env file when using the serve script. This should make it possible to configure the `.env.example` for valet and make it still usable with Docker.

Should the Docker command `bin/serve` maybe also be placed in the `Setup Environment` section of the docs?