### PR TITLE
Update websockets.php

### DIFF
--- a/config/websockets.php
+++ b/config/websockets.php
@@ -2,6 +2,9 @@
 
 use BeyondCode\LaravelWebSockets\Dashboard\Http\Middleware\Authorize;
 
+// WindowsOS & macOS path list.
+$homePath = $_SERVER['HOME'] ?? $_SERVER['USERPROFILE'] ?? $_SERVER['HOMEPATH'] ?? '';
+
 return [
 
     /*
@@ -116,13 +119,13 @@ return [
          * certificate chain of issuers. The private key also may be contained
          * in a separate file specified by local_pk.
          */
-        'local_cert' => $_SERVER['HOME'] . '/'.env('LARAVEL_WEBSOCKETS_SSL_LOCAL_CERT', null),
+        'local_cert' => $homePath . '/'.env('LARAVEL_WEBSOCKETS_SSL_LOCAL_CERT', null),
 
         /*
          * Path to local private key file on filesystem in case of separate files for
          * certificate (local_cert) and private key.
          */
-        'local_pk' => $_SERVER['HOME'] . '/'. env('LARAVEL_WEBSOCKETS_SSL_LOCAL_PK', null),
+        'local_pk' => $homePath . '/'. env('LARAVEL_WEBSOCKETS_SSL_LOCAL_PK', null),
 
         /*
          * Passphrase for your local_cert file.


### PR DESCRIPTION
Fixing path detect for Windows.

Fix to /config/websocket.php for Windows

On Windows, the $_SERVER['HOME'] environment variable may not be available, so $_SERVER['HOMEPATH'] or $_SERVER['USERPROFILE'] is often used as alternatives.

So one way to approach this would be to check if $_SERVER['HOME'] is defined, and if not, use one of these alternatives. Here is an example:

In this example, $homePath will be assigned to $_SERVER['HOME'] if it is defined; if not, it will check $_SERVER['USERPROFILE'], and then $_SERVER['HOMEPATH']. If none of these are defined, it will be an empty string.> In this example, $homePath will be assigned to $_SERVER['HOME'] if it is defined; if not, it will check $_SERVER['USERPROFILE'], and then $_SERVER['HOMEPATH']. If none of these are defined, it will be an empty string.